### PR TITLE
Docker: updates for PHP8 and cross-platform compatibility

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,40 +1,26 @@
-ergastdb:
-  container_name: ergastdb
-  build: ergastdb/
-  environment:
-    MYSQL_ROOT_PASSWORD: f1
-    MYSQL_DATABASE: ergastdb
-  expose:
-    - "3306"
+services:
 
-## Link an RStudio container to the ergastdb database server 
-#f1dj_rstudio:
-#  image: rocker/tidyverse 
-#  ports:
-#    - "8787:8787"
-#  links:
-#    - ergastdb:ergastdb
-#  volumes:
-#    - ./rstudio:/home/rstudio
-## Test the connection using:
-##library(RMySQL)
-##con=dbConnect(MySQL(),user='root',password='f1',host='ergastdb',port=3306,dbname='ergastdb')
-## dbListTables(con)  
+  ergastdb:
+    container_name: ergastdb
+    build: ergastdb/
+    environment:
+      MARIADB_ROOT_PASSWORD: f1
+      MARIADB_DATABASE: ergastdb
+      #MYSQL_ROOT_PASSWORD: f1
+      #MYSQL_DATABASE: ergastdb
+    expose:
+      - "3306"
 
-web:
-  build: ./lamp
-  #image: nimmis/apache-php5
-  ports:
-    - '8000:80'
-  volumes:
-    - ./webroot:/var/www/html
-    - ./php/api:/php/api
-    - ./logs:/var/log/apache2
-  links:
-    - ergastdb:ergastdb
-
+  web:
+    container_name: ergastweb
+    build: unit-php/
+    ports:
+      - '8000:80'
+    volumes:
+      - ./webroot:/var/www/html
+    links:
+      - ergastdb:ergastdb
     
 #docker-compose up --build -d
 #docker-compose build --force-rm
 #docker-compose up -d
-

--- a/ergastdb/Dockerfile
+++ b/ergastdb/Dockerfile
@@ -1,10 +1,5 @@
-FROM mysql
+FROM mariadb
 
-RUN sed -i -e"s/^bind-address\s*=\s*127.0.0.1/bind-address=0.0.0.0/" /etc/mysql/my.cnf
-
-RUN apt-get update && apt-get install -y wget && apt-get clean
-
-#ADD data/f1db.sql.gz /docker-entrypoint-initdb.d/f1db.sql.gz
-
-RUN wget http://ergast.com/downloads/f1db.sql.gz -P /docker-entrypoint-initdb.d
+RUN apt update && apt-get install -y curl
+RUN curl -o /docker-entrypoint-initdb.d/f1db.sql.gz http://ergast.com/downloads/f1db.sql.gz
 RUN gunzip /docker-entrypoint-initdb.d/f1db.sql.gz

--- a/lamp/Dockerfile
+++ b/lamp/Dockerfile
@@ -1,7 +1,0 @@
-FROM nimmis/apache-php5
-
-RUN sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
-
-
-
-RUN a2enmod rewrite

--- a/unit-php/Dockerfile
+++ b/unit-php/Dockerfile
@@ -1,0 +1,4 @@
+FROM unit:php
+ 
+RUN docker-php-ext-install mysqli
+ADD unitconf.json /docker-entrypoint.d/

--- a/unit-php/unitconf.json
+++ b/unit-php/unitconf.json
@@ -1,0 +1,15 @@
+{
+    "listeners": {
+        "*:80": {
+            "application": "ergast"
+        }
+    },
+
+    "applications": {
+        "ergast": {
+            "type": "php",
+            "root": "/var/www/html/php/api",
+            "script": "index.php"
+        }
+    }
+}

--- a/webroot/php/api/f1dbro.inc
+++ b/webroot/php/api/f1dbro.inc
@@ -2,7 +2,7 @@
 $user="root";
 $password="f1";
 $database="ergastdb";
-$mysqli = mysqli_connect("localhost", $user, $password);
+$mysqli = mysqli_connect("ergastdb", $user, $password);
 mysqli_set_charset($mysqli, "utf8");
 @mysqli_select_db($mysqli, $database) or die( "Unable to select database");
 ?>


### PR DESCRIPTION
Great to see the PHP8 update but a number of things stopped working for Docker environments.

This change aims to make Docker use more reliable, especially on Apple Silicon. Primary changes:

- MySQL replaced with MariaDB which has both x86 and arm64 images.
- PHP5 replaced with NGINX Unit (PHP8 runtime).
- Database connection reverted to "ergastdb" (had changed to "localhost").
